### PR TITLE
feat: add ENS name and avatar resolution

### DIFF
--- a/ios-wallet/ContentView.swift
+++ b/ios-wallet/ContentView.swift
@@ -48,6 +48,10 @@ final class WalletViewModel: ObservableObject {
     @Published var privateKeyError: String?
     @Published var didCopyPrivateKey: Bool = false
 
+    // ENS properties
+    @Published var ensName: String?
+    @Published var ensAvatarURL: String?
+
     init() {
         loadPersistedAddress()
         biometryAvailable = isBiometrySupported()
@@ -58,7 +62,10 @@ final class WalletViewModel: ObservableObject {
                 _ = KeyManagement.preflightAuthentication(addressHex: addressHex)
             }
         if hasWallet {
-            Task { await refreshAllBalances() }
+            Task { 
+                await refreshAllBalances()
+                await resolveENS()
+            }
         }
     }
 
@@ -128,7 +135,10 @@ final class WalletViewModel: ObservableObject {
             } else {
                 print("[Wallet] ERROR: Could not open app group defaults to save address")
             }
-            Task { await refreshAllBalances() }
+            Task { 
+                await refreshAllBalances()
+                await resolveENS()
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -149,7 +159,10 @@ final class WalletViewModel: ObservableObject {
             } else {
                 print("[Wallet] ERROR: Could not open app group defaults to save new wallet")
             }
-            Task { await refreshAllBalances() }
+            Task { 
+                await refreshAllBalances()
+                await resolveENS()
+            }
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -167,6 +180,8 @@ final class WalletViewModel: ObservableObject {
         addressHex = ""
         hasWallet = false
         balances.removeAll()
+        ensName = nil
+        ensAvatarURL = nil
         errorMessage = nil
     }
 
@@ -239,6 +254,17 @@ final class WalletViewModel: ObservableObject {
         let decimals = String(remainderStr.prefix(6))
         return "\(integer).\(decimals) ETH"
     }
+
+    @MainActor
+    func resolveENS() async {
+        guard !addressHex.isEmpty else { return }
+        
+        let ensData = await ENSService.shared.resolveENS(for: addressHex)
+        ensName = ensData?.ens
+        ensAvatarURL = ensData?.avatar
+    }
+    
+
 }
 
 private extension String {
@@ -262,6 +288,43 @@ struct ContentView: View {
         guard let uiImage = blockies.createImage() else { return nil }
 
         return Image(uiImage: uiImage)
+    }
+
+    // Profile image view that shows ENS avatar or falls back to blockies
+    @ViewBuilder
+    private func profileImage(size: CGFloat = 24) -> some View {
+        if let avatarURL = vm.ensAvatarURL, let url = URL(string: avatarURL) {
+            AsyncImage(url: url) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                if let blockies = blockiesImage(for: vm.addressHex, size: size) {
+                    blockies
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.gray.opacity(0.3))
+                }
+            }
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+            )
+        } else if let blockies = blockiesImage(for: vm.addressHex, size: size) {
+            blockies
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size, height: size)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                )
+        }
     }
 
     // Truncate address to show first and last 4 characters
@@ -325,21 +388,21 @@ struct ContentView: View {
                     Text("Address")
                         .font(.headline)
                     HStack(alignment: .center, spacing: 8) {
-                        if let blockies = blockiesImage(for: vm.addressHex, size: 24) {
-                            blockies
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 24, height: 24)
-                                .cornerRadius(4)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .stroke(Color.gray.opacity(0.2), lineWidth: 1)
-                                )
+                        profileImage(size: 24)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            if let ensName = vm.ensName, !ensName.isEmpty {
+                                Text(ensName)
+                                    .font(.system(.body, design: .default))
+                                    .foregroundColor(.primary)
+                                Text(truncatedAddress(vm.addressHex))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            } else {
+                                Text(truncatedAddress(vm.addressHex))
+                                    .font(.system(.footnote, design: .monospaced))
+                            }
                         }
-                        Text(truncatedAddress(vm.addressHex))
-                            .font(.system(.footnote, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
                         Spacer()
                         Button(action: {
                             UIPasteboard.general.string = vm.addressHex
@@ -377,6 +440,8 @@ struct ContentView: View {
                         }
                         Spacer()
                     }
+                    
+
 
                     HStack {
                         Button(role: .destructive, action: { showClearWalletConfirmation = true }) {
@@ -408,6 +473,7 @@ struct ContentView: View {
         }
         .refreshable {
             await vm.refreshAllBalances()
+            await vm.resolveENS()
         }
     }
 

--- a/ios-wallet/ENSService.swift
+++ b/ios-wallet/ENSService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+class ENSData: Codable {
+    let ens: String?
+    let avatar: String?
+    
+    init(ens: String?, avatar: String?) {
+        self.ens = ens
+        self.avatar = avatar
+    }
+}
+
+class ENSService {
+    static let shared = ENSService()
+    private let cache = NSCache<NSString, ENSData>()
+    
+    private init() {}
+    
+    func resolveENS(for address: String) async -> ENSData? {
+        if let cached = cache.object(forKey: address as NSString) {
+            print("[ENS] Using cached data for \(address)")
+            return cached
+        }
+        
+        guard let url = URL(string: "https://ensdata.net/\(address)") else { return nil }
+        
+        do {
+            print("[ENS] Fetching ENS data for \(address)")
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let ensData = try JSONDecoder().decode(ENSData.self, from: data)
+            cache.setObject(ensData, forKey: address as NSString)
+            print("[ENS] Resolved: ens=\(ensData.ens ?? "nil"), avatar=\(ensData.avatar ?? "nil")")
+            return ensData
+        } catch {
+            print("[ENS] Error resolving \(address): \(error)")
+            let emptyData = ENSData(ens: nil, avatar: nil)
+            cache.setObject(emptyData, forKey: address as NSString)
+            return emptyData
+        }
+    }
+}

--- a/web-ui/src/components/Address.tsx
+++ b/web-ui/src/components/Address.tsx
@@ -2,91 +2,113 @@ import React from "react";
 import { createIcon } from "@download/blockies";
 import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useENS } from "@/hooks/use-ens";
 
 type AddressProps = {
-  address: string;
-  className?: string;
-  mono?: boolean;
-  withEnsNameAbove?: string | null;
-  noLink?: boolean;
+	address: string;
+	className?: string;
+	mono?: boolean;
+	withEnsNameAbove?: string | null;
+	noLink?: boolean;
+	showEnsAvatar?: boolean;
 };
 
 function truncateMiddle(value: string, head = 6, tail = 4): string {
-  if (!value) return value;
-  if (value.length <= head + tail + 1) return value;
-  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+	if (!value) return value;
+	if (value.length <= head + tail + 1) return value;
+	return `${value.slice(0, head)}…${value.slice(-tail)}`;
 }
 
 export function Address({
-  address,
-  className,
-  mono,
-  withEnsNameAbove,
-  noLink = false,
+	address,
+	className,
+	mono,
+	withEnsNameAbove,
+	noLink = false,
+	showEnsAvatar = false,
 }: AddressProps) {
-  const ref = React.useRef<HTMLSpanElement | null>(null);
+	const ref = React.useRef<HTMLSpanElement | null>(null);
+	const { data: ensData } = useENS(showEnsAvatar ? address : null);
 
-  React.useEffect(() => {
-    if (!address || typeof address !== "string" || !address.startsWith("0x"))
-      return;
-    const canvas = createIcon({
-      seed: address.toLowerCase(),
-      size: 6,
-      scale: 3,
-    });
-    canvas.style.borderRadius = "4px";
-    canvas.style.flex = "0 0 auto";
-    const host = ref.current;
-    if (host) {
-      // Clear previous icon on rerenders
-      while (host.firstChild) host.removeChild(host.firstChild);
-      host.appendChild(canvas);
-    }
-    return () => {
-      if (host && canvas && canvas.parentNode === host)
-        host.removeChild(canvas);
-    };
-  }, [address]);
+	React.useEffect(() => {
+		if (!address || typeof address !== "string" || !address.startsWith("0x"))
+			return;
 
-  const content = noLink ? (
-    <span className={cn("inline-flex items-center gap-2", className)}>
-      <span ref={ref} aria-hidden="true" />
-      <span className={cn(mono ? "font-mono" : undefined, "break-all")}>
-        {truncateMiddle(address)}
-      </span>
-    </span>
-  ) : (
-    <a
-      href={`https://blockscan.com/address/${address}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn("inline-flex items-center gap-2", className)}
-    >
-      <span ref={ref} aria-hidden="true" />
-      <span className={cn(mono ? "font-mono" : undefined, "break-all")}>
-        {truncateMiddle(address)}
-      </span>
-      <ExternalLink className="h-3 w-3 opacity-60 flex-shrink-0" />
-    </a>
-  );
+		// Don't show blockies if we have an ENS avatar
+		if (showEnsAvatar && ensData?.avatar) return;
 
-  if (withEnsNameAbove) {
-    return (
-      <div>
-        <div className="text-foreground">{withEnsNameAbove}</div>
-        <div
-          className={cn(
-            mono ? "font-mono" : undefined,
-            "text-muted-foreground break-all"
-          )}
-        >
-          {content}
-        </div>
-      </div>
-    );
-  }
+		const canvas = createIcon({
+			seed: address.toLowerCase(),
+			size: 6,
+			scale: 3,
+		});
+		canvas.style.borderRadius = "4px";
+		canvas.style.flex = "0 0 auto";
+		const host = ref.current;
+		if (host) {
+			// Clear previous icon on rerenders
+			while (host.firstChild) host.removeChild(host.firstChild);
+			host.appendChild(canvas);
+		}
+		return () => {
+			if (host && canvas && canvas.parentNode === host)
+				host.removeChild(canvas);
+		};
+	}, [address, showEnsAvatar, ensData?.avatar]);
 
-  return content;
+	const avatarElement =
+		showEnsAvatar && ensData?.avatar ? (
+			<img
+				src={ensData.avatar}
+				alt={`${ensData.name || address} avatar`}
+				className="w-[18px] h-[18px] rounded border border-gray-200 flex-shrink-0"
+			/>
+		) : (
+			<span ref={ref} aria-hidden="true" />
+		);
+
+	const content = noLink ? (
+		<span className={cn("inline-flex items-center gap-2", className)}>
+			{avatarElement}
+			<span className={cn(mono ? "font-mono" : undefined, "break-all")}>
+				{truncateMiddle(address)}
+			</span>
+		</span>
+	) : (
+		<a
+			href={`https://blockscan.com/address/${address}`}
+			target="_blank"
+			rel="noopener noreferrer"
+			className={cn("inline-flex items-center gap-2", className)}
+		>
+			{avatarElement}
+			<span className={cn(mono ? "font-mono" : undefined, "break-all")}>
+				{truncateMiddle(address)}
+			</span>
+			<ExternalLink className="h-3 w-3 opacity-60 flex-shrink-0" />
+		</a>
+	);
+
+	const displayName =
+		withEnsNameAbove || (showEnsAvatar ? ensData?.name : null);
+
+	if (displayName) {
+		return (
+			<div>
+				<div className="text-foreground">{displayName}</div>
+				<div
+					className={cn(
+						mono ? "font-mono" : undefined,
+						"text-muted-foreground break-all",
+					)}
+				>
+					{content}
+				</div>
+			</div>
+		);
+	}
+
+	return content;
 }
 
 export default Address;

--- a/web-ui/src/components/ConnectModal.tsx
+++ b/web-ui/src/components/ConnectModal.tsx
@@ -64,7 +64,7 @@ export function ConnectModal({
                 Loading wallet address...
               </div>
             ) : walletAddress ? (
-              <Address address={walletAddress} mono />
+              <Address address={walletAddress} mono showEnsAvatar />
             ) : (
               <div className="text-muted-foreground">
                 No wallet address available

--- a/web-ui/src/components/RequestModal.tsx
+++ b/web-ui/src/components/RequestModal.tsx
@@ -75,6 +75,7 @@ export function RequestModal({
                   className="inline-flex items-center text-xs text-muted-foreground"
                   mono
                   noLink
+                  showEnsAvatar
                 />
               )}
             </div>

--- a/web-ui/src/hooks/use-ens.ts
+++ b/web-ui/src/hooks/use-ens.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+export interface ENSData {
+	name: string | null;
+	avatar: string | null;
+}
+
+export function useENS(address?: string | null): {
+	data: ENSData | undefined;
+	isLoading: boolean;
+	error: Error | null;
+} {
+	const { data, isLoading, error } = useQuery({
+		queryKey: ["ens", address?.toLowerCase()],
+		queryFn: async (): Promise<ENSData> => {
+			if (!address || !address.startsWith("0x")) {
+				return { name: null, avatar: null };
+			}
+
+			const client = createPublicClient({
+				chain: mainnet,
+				transport: http(),
+			});
+
+			try {
+				const [name, avatar] = await Promise.all([
+					client.getEnsName({ address: address as `0x${string}` }),
+					client
+						.getEnsAvatar({ name: address as `0x${string}` })
+						.catch(() => null),
+				]);
+
+				// If we got a name, try to get the avatar using the name
+				const finalAvatar =
+					name && !avatar
+						? await client.getEnsAvatar({ name }).catch(() => null)
+						: avatar;
+
+				return {
+					name,
+					avatar: finalAvatar,
+				};
+			} catch {
+				return { name: null, avatar: null };
+			}
+		},
+		enabled: Boolean(address?.startsWith("0x")),
+		staleTime: 5 * 60 * 1000, // 5 minutes
+		gcTime: 10 * 60 * 1000, // 10 minutes
+	});
+
+	return {
+		data,
+		isLoading,
+		error: error as Error | null,
+	};
+}


### PR DESCRIPTION
## Summary

- Add ENS name and avatar support across iOS and web platforms
- Implement consistent ENS display for wallet addresses in all UI components

## Changes

iOS Implementation:

• Add `ENSService.swift` with caching ENS resolver using ensdata.net API
• Update `ContentView.swift` to display ENS names and avatars in wallet interface
• Show ENS names above addresses with fallback to blockies identicons
• Add profile image component supporting both ENS avatars and generated blockies

Web Implementation:

• Create reusable `useENS` hook using viem's `getEnsName()` and `getEnsAvatar()` actions
• Update `Address` component to support ENS names and avatars with `showEnsAvatar` prop
• Enable ENS display in `ConnectModal` for wallet connection flows
• Update `RequestModal` footer to show ENS data for all signing operations
• Add 5-minute caching to prevent excessive ENS API calls

## Screenshots 

| iOS Wallet | Connect Modal | Request Modal |
|:---:|:---:|:---:|
| <img width="250" alt="iOS Wallet - ENS Profile View" src="https://github.com/user-attachments/assets/b31179e8-8e0d-491d-b30e-f282e4858186" /> | <img width="250" alt="iOS Wallet - Connect Modal" src="https://github.com/user-attachments/assets/9024a35c-d096-4288-8abf-9711318d9836" /> | <img width="250" alt="iOS Wallet - Request Modal" src="https://github.com/user-attachments/assets/842a9ae4-ce19-4c6a-9cd6-eba6a2b97aa7" /> |
