### PR TITLE
Implement eth_getTransactionByHash support

### DIFF
--- a/safari/Resources/background.js
+++ b/safari/Resources/background.js
@@ -168,6 +168,7 @@ async function handleWalletRequest(message, sender, sendResponse) {
       }
       case "eth_chainId":
       case "eth_blockNumber":
+      case "eth_getTransactionByHash":
       case "wallet_addEthereumChain":
       case "wallet_getCapabilities":
       case "wallet_getCallsStatus":

--- a/safari/Resources/inject.js
+++ b/safari/Resources/inject.js
@@ -55,6 +55,7 @@
         }
 
         case "eth_blockNumber":
+        case "eth_getTransactionByHash":
         case "wallet_addEthereumChain":
         case "wallet_getCapabilities":
         case "eth_signTypedData_v4":

--- a/safari/SafariWebExtensionHandler.swift
+++ b/safari/SafariWebExtensionHandler.swift
@@ -138,6 +138,9 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             return handleChainId()
         case "eth_blockNumber":
             return handleBlockNumber()
+        case "eth_getTransactionByHash":
+            let params = messageDict["params"] as? [Any]
+            return handleGetTransactionByHash(params: params)
         case "personal_sign":
             let params = messageDict["params"] as? [Any]
             return handlePersonalSign(params: params)
@@ -203,6 +206,87 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             return ["result": num.hex()]
         case .failure:
             return ["error": "Failed to get block number"]
+        }
+    }
+
+    private func handleGetTransactionByHash(params: [Any]?) -> [String: Any] {
+        guard let params = params, params.count >= 1 else {
+            return ["error": "Invalid eth_getTransactionByHash params"]
+        }
+        guard let txHashHex = params[0] as? String else {
+            return ["error": "Invalid transaction hash"]
+        }
+        
+        let (rpcURL, _) = Constants.Networks.currentNetwork()
+        let web3 = Web3(rpcURL: rpcURL)
+        
+        // Convert hex string to EthereumData
+        guard let txHashData = Data(hexString: txHashHex) else {
+            return ["error": "Invalid transaction hash format"]
+        }
+        
+        let txHash = EthereumData([UInt8](txHashData))
+        
+        switch awaitPromise(web3.eth.getTransactionByHash(blockHash: txHash)) {
+        case .success(let transaction):
+            guard let tx = transaction else {
+                return ["result": nil]
+            }
+            
+            // Format transaction response according to Ethereum JSON-RPC spec
+            var result: [String: Any] = [
+                "hash": tx.hash.hex(),
+                "nonce": tx.nonce?.hex() ?? "0x0",
+                "blockHash": tx.blockHash?.hex() ?? nil,
+                "blockNumber": tx.blockNumber?.hex() ?? nil,
+                "transactionIndex": tx.transactionIndex?.hex() ?? nil,
+                "from": tx.from?.hex(eip55: true) ?? "",
+                "to": tx.to?.hex(eip55: true) ?? nil,
+                "value": tx.value?.hex() ?? "0x0",
+                "gas": tx.gasLimit?.hex() ?? "0x0",
+                "gasPrice": tx.gasPrice?.hex() ?? "0x0",
+                "input": tx.data.hex(),
+                "v": tx.v?.hex() ?? "0x0",
+                "r": tx.r?.hex() ?? "0x0",
+                "s": tx.s?.hex() ?? "0x0"
+            ]
+            
+            // Add EIP-1559 fields if present
+            if let maxFeePerGas = tx.maxFeePerGas {
+                result["maxFeePerGas"] = maxFeePerGas.hex()
+            }
+            if let maxPriorityFeePerGas = tx.maxPriorityFeePerGas {
+                result["maxPriorityFeePerGas"] = maxPriorityFeePerGas.hex()
+            }
+            
+            // Add access list for EIP-2930 transactions
+            if !tx.accessList.isEmpty {
+                var accessList: [[String: Any]] = []
+                for (address, storageKeys) in tx.accessList {
+                    var accessItem: [String: Any] = [
+                        "address": address.hex(eip55: true),
+                        "storageKeys": storageKeys.map { $0.hex() }
+                    ]
+                    accessList.append(accessItem)
+                }
+                result["accessList"] = accessList
+            }
+            
+            // Add transaction type for EIP-2718
+            if let transactionType = tx.transactionType {
+                switch transactionType {
+                case .legacy:
+                    result["type"] = "0x0"
+                case .eip1559:
+                    result["type"] = "0x2"
+                case .eip2930:
+                    result["type"] = "0x1"
+                }
+            }
+            
+            return ["result": result]
+        case .failure(let error):
+            return ["error": "Failed to get transaction: \(error.localizedDescription)"]
         }
     }
 

--- a/web-ui/src/lib/constants.ts
+++ b/web-ui/src/lib/constants.ts
@@ -13,6 +13,7 @@ export const FAST_METHODS = [
   "eth_accounts",
   "eth_chainId",
   "eth_blockNumber",
+  "eth_getTransactionByHash",
   "wallet_addEthereumChain",
   "wallet_switchEthereumChain",
   "wallet_disconnect",


### PR DESCRIPTION
Implement `eth_getTransactionByHash` to allow DApps to retrieve transaction details by hash.

---
<a href="https://cursor.com/background-agent?bcId=bc-04153dfe-1283-41b0-9be8-a2a5420f2276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04153dfe-1283-41b0-9be8-a2a5420f2276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `eth_getTransactionByHash` across inject/background handlers and native Swift, and marks it as a fast method in the web UI.
> 
> - **RPC support**:
>   - **Native (Swift)**: Add `handleGetTransactionByHash` in `SafariWebExtensionHandler.swift` with input validation, hex parsing, and `web3.eth.getTransactionByHash` call; wire new case in request switch.
>   - **Extension routing**: Pass through `eth_getTransactionByHash` in `safari/Resources/inject.js` and `safari/Resources/background.js` via existing `_handleRequest`/native bridge.
>   - **Web UI**: Add `eth_getTransactionByHash` to `FAST_METHODS` in `web-ui/src/lib/constants.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2a0e23523c38acac43276c94124ce22ac496232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->