### PR TITLE
feat: add eth_call support as fast method

### DIFF
--- a/safari/Resources/background.js
+++ b/safari/Resources/background.js
@@ -169,6 +169,7 @@ async function handleWalletRequest(message, sender, sendResponse) {
       case "net_version":
       case "eth_blockNumber":
       case "eth_estimateGas":
+      case "eth_call":
       case "eth_getCode":
       case "eth_getTransactionByHash":
       case "eth_getTransactionReceipt":

--- a/safari/Resources/inject.js
+++ b/safari/Resources/inject.js
@@ -61,6 +61,7 @@
 
         case "eth_blockNumber":
         case "eth_estimateGas":
+        case "eth_call":
         case "eth_getCode":
         case "eth_getTransactionByHash":
         case "eth_getTransactionReceipt":

--- a/web-ui/src/lib/constants.ts
+++ b/web-ui/src/lib/constants.ts
@@ -15,6 +15,7 @@ export const FAST_METHODS = [
   "net_version",
   "eth_blockNumber",
   "eth_estimateGas",
+  "eth_call",
   "eth_getCode",
   "eth_getTransactionByHash",
   "eth_getTransactionReceipt",


### PR DESCRIPTION
## Summary
- Adds `eth_call` RPC method support as a fast method (no user confirmation required)
- Follows guidelines in CONTRIBUTING.md for adding new RPC methods

## Changes
- Added `eth_call` to `FAST_METHODS` in `web-ui/src/lib/constants.ts`
- Added `eth_call` case to fast methods switch in `safari/Resources/background.js`
- Implemented `handleEthCall` handler in `safari/SafariWebExtensionHandler.swift` using JSONRPC utility
- Added `eth_call` case to request switch in `safari/Resources/inject.js`

## Implementation Details
- Uses shared `JSONRPC.request` utility for direct RPC passthrough
- Returns raw hex string response or "0x" for null responses
- Follows same pattern as other fast RPC methods like `eth_estimateGas` and `eth_getCode`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds fast-path support for `eth_call` aligned with existing read-only RPCs.
> 
> - Adds `eth_call` to `FAST_METHODS` in `web-ui/src/lib/constants.ts`
> - Routes `eth_call` through fast-method switches in `safari/Resources/background.js` and `safari/Resources/inject.js`
> - Implements `handleEthCall` in `safari/SafariWebExtensionHandler.swift` using `JSONRPC.request`; returns raw hex string and maps `null` to `"0x"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d248bde60c747d106d995e778bc5c9bf9d131c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->