### PR TITLE
fix: keep wallet modal above site dialogs

### DIFF
--- a/docs/ConnectedState.md
+++ b/docs/ConnectedState.md
@@ -373,6 +373,12 @@ Acceptance:
   - Iframe/embedded contexts: domain extraction yields correct hostname.
   - Multi-tab: connection shared across tabs for same domain.
 
+##### Implementation Notes (Modal Layering)
+
+- The injected wallet UI host now uses a native `<dialog>` container when `showModal()` is available, falling back to the previous fixed `<div>` host otherwise.
+- During an active wallet request, `App` calls `showModal()` so the wallet confirmation UI enters the browser top layer. This avoids site-owned modal/dialog UI, such as networked.art sign-in modals, rendering above the wallet confirmation despite the wallet host already using the maximum CSS z-index.
+- The native dialog backdrop is transparent; the existing wallet overlay remains responsible for dimming and interaction blocking.
+
 Acceptance:
 
 - All acceptance criteria from the Testing section pass on Simulator.

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -18,7 +18,7 @@ type ModalState = {
   resolve: (r: ApprovalResult) => void;
 };
 
-export function App({ container }: { container: HTMLDivElement }) {
+export function App({ container }: { container: HTMLElement }) {
   const [modal, setModal] = React.useState<ModalState | null>(null);
 
   const normalizePersonalSignParams = React.useCallback(
@@ -133,6 +133,13 @@ export function App({ container }: { container: HTMLDivElement }) {
   React.useEffect(() => {
     try {
       container.style.pointerEvents = modal ? "auto" : "none";
+      if (container instanceof HTMLDialogElement) {
+        if (modal && !container.open) {
+          container.showModal();
+        } else if (!modal && container.open) {
+          container.close();
+        }
+      }
     } catch {}
   }, [modal, container]);
 
@@ -168,35 +175,27 @@ export function App({ container }: { container: HTMLDivElement }) {
   };
 
   const onReject = async () => {
-    try {
-      const finalResponse = await browser.runtime.sendMessage({
-        type: "WALLET_CONFIRM",
-        approved: false,
-        method: modal.method,
-        params: computeParams(),
-        requestId: modal.requestId,
-      });
-      modal.resolve({ approved: false, finalResponse });
-      setModal(null);
-    } catch (e) {
-      throw e;
-    }
+    const finalResponse = await browser.runtime.sendMessage({
+      type: "WALLET_CONFIRM",
+      approved: false,
+      method: modal.method,
+      params: computeParams(),
+      requestId: modal.requestId,
+    });
+    modal.resolve({ approved: false, finalResponse });
+    setModal(null);
   };
 
   const onApprove = async () => {
-    try {
-      const finalResponse = await browser.runtime.sendMessage({
-        type: "WALLET_CONFIRM",
-        approved: true,
-        method: modal.method,
-        params: computeParams(),
-        requestId: modal.requestId,
-      });
-      modal.resolve({ approved: true, finalResponse });
-      setModal(null);
-    } catch (e) {
-      throw e;
-    }
+    const finalResponse = await browser.runtime.sendMessage({
+      type: "WALLET_CONFIRM",
+      approved: true,
+      method: modal.method,
+      params: computeParams(),
+      requestId: modal.requestId,
+    });
+    modal.resolve({ approved: true, finalResponse });
+    setModal(null);
   };
 
   if (

--- a/web-ui/src/shadow.css
+++ b/web-ui/src/shadow.css
@@ -23,6 +23,10 @@
   --ring: oklch(0.708 0 0);
 }
 
+:host::backdrop {
+  background: transparent;
+}
+
 :host(.dark) {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);

--- a/web-ui/src/shadowHost.ts
+++ b/web-ui/src/shadowHost.ts
@@ -4,7 +4,7 @@ import { createRoot, Root } from "react-dom/client";
 import shadowCss from "./shadow.css?inline";
 
 export type ShadowMount = {
-  container: HTMLDivElement;
+  container: HTMLElement;
   cleanup: () => void;
   root: Root;
   shadow: ShadowRoot | HTMLElement;
@@ -18,12 +18,26 @@ export function getPortalContainer(): HTMLDivElement | null {
 }
 
 export function createShadowMount(): ShadowMount {
-  const container = document.createElement("div");
+  const supportsModalDialog =
+    typeof HTMLDialogElement !== "undefined" &&
+    typeof HTMLDialogElement.prototype.showModal === "function";
+  const container = document.createElement(
+    supportsModalDialog ? "dialog" : "div"
+  ) as HTMLElement;
   container.id = "stupid-wallet-modal-root";
   container.style.position = "fixed";
   container.style.inset = "0";
   container.style.zIndex = "2147483647";
   container.style.pointerEvents = "none";
+  container.style.width = "100vw";
+  container.style.height = "100vh";
+  container.style.maxWidth = "none";
+  container.style.maxHeight = "none";
+  container.style.margin = "0";
+  container.style.padding = "0";
+  container.style.border = "0";
+  container.style.background = "transparent";
+  container.style.color = "inherit";
 
   let shadow: ShadowRoot | HTMLElement;
   try {
@@ -32,7 +46,7 @@ export function createShadowMount(): ShadowMount {
     } else {
       shadow = container;
     }
-  } catch (_) {
+  } catch {
     // Fallback for environments where Shadow DOM is restricted
     shadow = container;
   }
@@ -101,6 +115,11 @@ export function createShadowMount(): ShadowMount {
   const cleanup = () => {
     try {
       root.unmount();
+    } catch {}
+    try {
+      if (container instanceof HTMLDialogElement && container.open) {
+        container.close();
+      }
     } catch {}
     container.remove();
     if (currentPortalContainer === portalEl) {


### PR DESCRIPTION
## Summary
- promote the injected wallet UI host to a native modal dialog when supported
- open/close the dialog only while wallet requests are active so it enters the browser top layer
- keep the native dialog backdrop transparent and document the modal layering behavior

## Verification
- bunx oxlint "src/App.tsx" "src/shadowHost.ts"
- bun run build
- built, installed, and launched the app on simulator NoFeedSocial iOS 26.3